### PR TITLE
1.0.1-SNAPSHOT: `utilities` patch and updated Neo4J

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Neo-storr
+
+This project provides some Java utility classes for storing objects in data structures.
+
+![Java CI with Maven](https://github.com/stacs-srg/neo-storr/workflows/Java%20CI%20with%20Maven/badge.svg)
+
+## Usage via maven
+        
+```
+<dependency>
+    <groupId>uk.ac.standrews.cs</groupId>
+    <artifactId>neo-storr</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
+</dependency>
+...
+<repository>
+    <id>uk.ac.standrews.cs.maven.repository</id>
+    <name>School of Computer Science Maven Repository</name>
+    <url>https://maven.cs.st-andrews.ac.uk/</url>
+</repository>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>uk.ac.standrews.cs</groupId>
         <artifactId>common-pom</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>neo-storr</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>neo-storr</name>
 
@@ -37,8 +37,8 @@
     <properties>
 
         <commons-lang3-version>3.18.0</commons-lang3-version>
-        <neo4j-version>4.4.0</neo4j-version>
-        <neo4j-java-driver-version>4.4.1</neo4j-java-driver-version>
+        <neo4j-version>5.26.9</neo4j-version>
+        <neo4j-java-driver-version>5.26.3</neo4j-java-driver-version>
 
     </properties>
 
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>uk.ac.standrews.cs</groupId>
             <artifactId>utilities</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -83,6 +83,13 @@
             <version>${neo4j-java-driver-version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.neo4j.test</groupId>
+            <artifactId>neo4j-harness</artifactId>
+            <version>${neo4j-version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -91,33 +98,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
-
-                <!-- Don't run tests by default since they depend on neo4j being installed. -->
                 <configuration>
-                    <skipTests>true</skipTests>
+                    <parallel>none</parallel>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>enable-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven-surefire-plugin.version}</version>
-
-                        <configuration>
-                            <skipTests>false</skipTests>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <developers>
 

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/impl/LXPReference.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/impl/LXPReference.java
@@ -113,10 +113,10 @@ public class LXPReference<T extends LXP> extends StaticLXP implements IStoreRefe
         return getReferend(getBucket());
     }
 
-    public T getReferend(final Class clazz) throws BucketException, RepositoryException {
+    public T getReferend(final Class c) throws BucketException, RepositoryException {
 
         // TODO class is ignored if this reference was created using an explicit reference.
-        return getReferend(getBucket(clazz));
+        return getReferend(getBucket(c));
     }
 
     private T getReferend(final IBucket<T> bucket) throws BucketException {
@@ -139,7 +139,7 @@ public class LXPReference<T extends LXP> extends StaticLXP implements IStoreRefe
         }
     }
 
-    private IBucket<T> getBucket(final Class clazz) throws RepositoryException {
+    private IBucket<T> getBucket(final Class c) throws RepositoryException {
 
         if (ref != null) {
             T obj = ref.get();
@@ -148,7 +148,7 @@ public class LXPReference<T extends LXP> extends StaticLXP implements IStoreRefe
             }
         }
 
-        return Store.getInstance().getRepository(getRepositoryName()).getBucket(getBucketName(), clazz);
+        return Store.getInstance().getRepository(getRepositoryName()).getBucket(getBucketName(), c);
     }
 
     public IBucket getBucket() throws RepositoryException {

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/impl/NeoBackedBucket.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/impl/NeoBackedBucket.java
@@ -110,8 +110,8 @@ public class NeoBackedBucket<T extends LXP> implements IBucket<T> {
         return getPersistentTypeLabelID() == type_label_id;
     }
 
-    public boolean bucketTypeIsCorrect(final Class<?> clazz) {
-        return clazz.equals(bucket_type);
+    public boolean bucketTypeIsCorrect(final Class<?> c) {
+        return c.equals(bucket_type);
     }
 
     public long getPersistentTypeLabelID() {
@@ -349,14 +349,14 @@ public class NeoBackedBucket<T extends LXP> implements IBucket<T> {
 
         record_to_write.$$$bucket$$$bucket$$$ = this;
 
-        final Class<?> clazz = record_to_write.getMetaData().metadata_class;
+        final Class<?> c = record_to_write.getMetaData().metadata_class;
 
         final Map<String, Object> properties = record_to_write.serializeFieldsToMap();
         properties.put("STORR_ID", record_to_write.getId());
 
         final boolean auto_commit = store.getTransactionManager().isAutoCommitEnabled();
         final Transaction tx = getTransaction(auto_commit);
-        runWriteLXPQuery(record_to_write, properties, clazz, tx);
+        runWriteLXPQuery(record_to_write, properties, c, tx);
         if (auto_commit) tx.commit();
     }
 
@@ -375,9 +375,9 @@ public class NeoBackedBucket<T extends LXP> implements IBucket<T> {
         return storr_transaction;
     }
 
-    private void runWriteLXPQuery(final LXP record_to_write, final Map<String, Object> properties, final Class<?> clazz, final Transaction tx) throws BucketException {
+    private void runWriteLXPQuery(final LXP record_to_write, final Map<String, Object> properties, final Class<?> c, final Transaction tx) throws BucketException {
 
-        final String query = clazz != null ? buildParameterisedWriteLXPQuery(clazz) : CREATE_LXP_QUERY;
+        final String query = c != null ? buildParameterisedWriteLXPQuery(c) : CREATE_LXP_QUERY;
         final Result result = tx.run(query, Values.parameters("props", properties));
 
         final List<Node> nodes = result.list(r -> r.get("n").asNode());
@@ -387,9 +387,9 @@ public class NeoBackedBucket<T extends LXP> implements IBucket<T> {
         tx.run(ADD_LXP_TO_BUCKET_QUERY, Values.parameters("bucket_id", neo_id, "new_id", nodes.get(0).id()));
     }
 
-    private String buildParameterisedWriteLXPQuery(Class<?> clazz) {
+    private String buildParameterisedWriteLXPQuery(Class<?> c) {
 
-        return "CREATE (n:STORR_LXP:" + clazz.getSimpleName() + " $props) RETURN n";
+        return "CREATE (n:STORR_LXP:" + c.getSimpleName() + " $props) RETURN n";
     }
 
     public synchronized int size() {

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/impl/NeoBackedBucket.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/impl/NeoBackedBucket.java
@@ -367,7 +367,7 @@ public class NeoBackedBucket<T extends LXP> implements IBucket<T> {
 
     private ITransaction getCurrentStorrTransaction() throws BucketException {
 
-        final ITransaction storr_transaction = store.getTransactionManager().getTransaction(Long.toString(Thread.currentThread().getId()));
+        final ITransaction storr_transaction = store.getTransactionManager().getTransaction(Long.toString(Thread.currentThread().threadId()));
 
         if (storr_transaction == null || !storr_transaction.isActive()) {
             throw new BucketException("No transactional context specified");

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/impl/Repository.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/impl/Repository.java
@@ -94,7 +94,10 @@ public class Repository implements IRepository {
         if (bucketExists(bucket_name)) throw new RepositoryException("Repo: " + bucket_name + " already exists");
 
         try (final Session session = bridge.getNewSession()) {
-            session.writeTransaction(tx -> tx.run(MAKE_BUCKET_QUERY, parameters("repo_name", repository_name, "bucket_name", bucket_name)));
+            session.executeWrite(tx -> {
+                tx.run(MAKE_BUCKET_QUERY, parameters("repo_name", repository_name, "bucket_name", bucket_name)).consume();
+                return null;
+            });
         }
     }
 
@@ -127,7 +130,10 @@ public class Repository implements IRepository {
     public void deleteBucket(final String bucket_name) {
 
         try (final Session session = bridge.getNewSession();) {
-            session.writeTransaction(tx -> tx.run(DELETE_BUCKET_QUERY, parameters("repo_name", this.repository_name, "bucket_name", bucket_name)));
+            session.executeWrite(tx -> {
+                tx.run(DELETE_BUCKET_QUERY, parameters("repo_name", this.repository_name, "bucket_name", bucket_name)).consume();
+                return null;
+            });
         }
         bucket_cache.remove(bucket_name);
     }

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/impl/StaticLXP.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/impl/StaticLXP.java
@@ -64,9 +64,9 @@ public abstract class StaticLXP extends LXP {
                 final String class_name = extractRefType((LXPReferenceType) type);
 
                 try {
-                    final Class clazz = getClass(class_name);
+                    final Class c = getClass(class_name);
 
-                    final Method makeref = clazz.getDeclaredMethod("makeRef", String.class);
+                    final Method makeref = c.getDeclaredMethod("makeRef", String.class);
                     final LXPReference newref = (LXPReference) makeref.invoke(null, serialised);
                     put(label, newref);
 
@@ -83,18 +83,18 @@ public abstract class StaticLXP extends LXP {
 
         while (iterator.hasNext()) {
 
-            final Class clazz = iterator.next();
-            if (clazz.getSimpleName().equals(name)) return clazz;
+            final Class c = iterator.next();
+            if (c.getSimpleName().equals(name)) return c;
         }
         throw new ClassNotFoundException("Could not find a loaded class with name <" + name + ">");
     }
 
     private static Iterator<Class> getLoadedClasses(final ClassLoader class_loader) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 
-        Class clazz = class_loader.getClass();
-        while (clazz != ClassLoader.class) clazz = clazz.getSuperclass();
+        Class c = class_loader.getClass();
+        while (c != ClassLoader.class) c = c.getSuperclass();
 
-        final Field f = clazz.getDeclaredField("classes");
+        final Field f = c.getDeclaredField("classes");
         f.setAccessible(true);
         return ((Vector<Class>) f.get(class_loader)).iterator();
     }

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/impl/transaction/impl/Transaction.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/impl/transaction/impl/Transaction.java
@@ -42,7 +42,7 @@ public class Transaction implements ITransaction {
 
     Transaction(final TransactionManager transaction_manager) {
 
-        transaction_id = String.valueOf(Thread.currentThread().getId()); // TODO this is good enough for a single machine - need to do more work for multiple node support
+        transaction_id = String.valueOf(Thread.currentThread().threadId()); // TODO this is good enough for a single machine - need to do more work for multiple node support
         session = transaction_manager.getBridge().getNewSession();
         tx = session.beginTransaction();
     }

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/interfaces/IStoreReference.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/interfaces/IStoreReference.java
@@ -32,7 +32,7 @@ public interface IStoreReference<T extends PersistentObject> {
 
     long getObjectId();
 
-    T getReferend(Class clazz) throws BucketException, RepositoryException;
+    T getReferend(Class c) throws BucketException, RepositoryException;
 
     LXP getReferend() throws RepositoryException, BucketException;
 }

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/types/Types.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/types/Types.java
@@ -170,20 +170,20 @@ public class Types {
         throw new RuntimeException("Encountered reference to type not defined: " + value);
     }
 
-    public static DynamicLXP getTypeRep(final Class clazz) {
+    public static DynamicLXP getTypeRep(final Class c) {
 
-        if (StaticLXP.class.isAssignableFrom(clazz) || DynamicLXP.class.isAssignableFrom(clazz)) {
-            return getLXPTypeRep(clazz);
+        if (StaticLXP.class.isAssignableFrom(c) || DynamicLXP.class.isAssignableFrom(c)) {
+            return getLXPTypeRep(c);
         }
 
-        throw new RuntimeException("Do not recognise persistent class: " + clazz.getName());
+        throw new RuntimeException("Do not recognise persistent class: " + c.getName());
     }
 
-    public static DynamicLXP getLXPTypeRep(final Class clazz) {
+    public static DynamicLXP getLXPTypeRep(final Class c) {
 
         final DynamicLXP type_rep = new DynamicLXP();
 
-        for (final Field f : clazz.getDeclaredFields()) {
+        for (final Field f : c.getDeclaredFields()) {
 
             if (Modifier.isStatic(f.getModifiers())) {
 

--- a/src/main/java/uk/ac/standrews/cs/neoStorr/util/NeoDbCypherBridge.java
+++ b/src/main/java/uk/ac/standrews/cs/neoStorr/util/NeoDbCypherBridge.java
@@ -26,7 +26,8 @@ public class NeoDbCypherBridge extends NeoDbBridge implements AutoCloseable {
     private final Driver driver;
 
     public NeoDbCypherBridge() {
-        this(DEFAULT_URL, DEFAULT_USER, DEFAULT_PASSWORD);
+        // Note: NeoDBTestURL can be set for unit-testing with Neo4j-harness
+        this(System.getProperty("NeoDBTestURL", DEFAULT_URL), DEFAULT_USER, DEFAULT_PASSWORD);
     }
 
     public NeoDbCypherBridge(String url, String user, String password) {

--- a/src/test/java/uk/ac/standrews/cs/neoStorr/impl/CommonTest.java
+++ b/src/test/java/uk/ac/standrews/cs/neoStorr/impl/CommonTest.java
@@ -16,13 +16,24 @@
  */
 package uk.ac.standrews.cs.neoStorr.impl;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.neo4j.harness.Neo4j;
+import org.neo4j.harness.Neo4jBuilders;
+
 import uk.ac.standrews.cs.neoStorr.impl.exceptions.RepositoryException;
 import uk.ac.standrews.cs.neoStorr.interfaces.IRepository;
 import uk.ac.standrews.cs.neoStorr.interfaces.IStore;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public abstract class CommonTest {
 
@@ -32,6 +43,8 @@ public abstract class CommonTest {
     protected IStore store;
     protected IRepository repository;
 
+    static Neo4j neo4jDb;
+    
     public static void main(String[] args) throws RepositoryException {
 
         // Run this to delete existing repository.
@@ -42,7 +55,16 @@ public abstract class CommonTest {
         System.exit(0);
     }
 
-    @Before
+    @BeforeAll
+    static void setUpNeo() {
+        neo4jDb = Neo4jBuilders.newInProcessBuilder()
+                .build();
+        // Sets override for neo-storr.neoDbCypherBridge
+        System.setProperty("NeoDBTestURL", neo4jDb.boltURI().toString());
+    }
+    
+
+    @BeforeEach
     public void setUp() throws Exception {
 
         store = Store.getInstance();
@@ -54,12 +76,28 @@ public abstract class CommonTest {
         repository.makeBucket(BUCKET_NAME);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws RepositoryException {
 
         repository.deleteBucket(BUCKET_NAME);
         store.deleteRepository(REPOSITORY_NAME);
 
         assertFalse(store.repositoryExists(REPOSITORY_NAME));
+    }
+
+    @AfterAll
+    static void tearDownNeo() {
+        System.clearProperty("NeoDBTestURL");
+    }
+
+    @Test
+    public void testNeo4jConnection() {
+        String testString = "Hello world";
+        Driver driver = GraphDatabase.driver(neo4jDb.boltURI(), AuthTokens.none());
+
+        try (Session session = driver.session()) {
+            String response = session.run("RETURN '"+testString+"'").single().get(0).asString();
+             assertEquals(testString, response);
+        }
     }
 }

--- a/src/test/java/uk/ac/standrews/cs/neoStorr/impl/ObjectsWithReferencesTest.java
+++ b/src/test/java/uk/ac/standrews/cs/neoStorr/impl/ObjectsWithReferencesTest.java
@@ -16,9 +16,9 @@
  */
 package uk.ac.standrews.cs.neoStorr.impl;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.ac.standrews.cs.neoStorr.impl.exceptions.BucketException;
 import uk.ac.standrews.cs.neoStorr.impl.exceptions.RepositoryException;
 import uk.ac.standrews.cs.neoStorr.impl.testData.DynamicPersonReference;
@@ -27,8 +27,7 @@ import uk.ac.standrews.cs.neoStorr.impl.testData.StaticPersonReference;
 import uk.ac.standrews.cs.neoStorr.interfaces.IBucket;
 import uk.ac.standrews.cs.neoStorr.interfaces.IStoreReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ObjectsWithReferencesTest extends CommonTest {
 
@@ -40,7 +39,7 @@ public class ObjectsWithReferencesTest extends CommonTest {
     private IBucket<StaticPersonReference> typed_bucket2;
     private IBucket untyped_bucket;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         super.setUp();
@@ -51,7 +50,7 @@ public class ObjectsWithReferencesTest extends CommonTest {
         untyped_bucket = repository.makeBucket(UNTYPED_BUCKET_NAME);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws RepositoryException {
 
         repository.deleteBucket(TYPED_BUCKET_NAME1);

--- a/src/test/java/uk/ac/standrews/cs/neoStorr/impl/StoreTest.java
+++ b/src/test/java/uk/ac/standrews/cs/neoStorr/impl/StoreTest.java
@@ -16,7 +16,7 @@
  */
 package uk.ac.standrews.cs.neoStorr.impl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.standrews.cs.neoStorr.impl.exceptions.RepositoryException;
 import uk.ac.standrews.cs.neoStorr.impl.testData.Car;
 import uk.ac.standrews.cs.neoStorr.impl.testData.JPOPerson;
@@ -27,7 +27,7 @@ import uk.ac.standrews.cs.neoStorr.interfaces.IRepository;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StoreTest extends CommonTest {
 

--- a/src/test/java/uk/ac/standrews/cs/neoStorr/impl/TransactionsTest.java
+++ b/src/test/java/uk/ac/standrews/cs/neoStorr/impl/TransactionsTest.java
@@ -16,9 +16,9 @@
  */
 package uk.ac.standrews.cs.neoStorr.impl;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.ac.standrews.cs.neoStorr.impl.exceptions.BucketException;
 import uk.ac.standrews.cs.neoStorr.impl.exceptions.RepositoryException;
 import uk.ac.standrews.cs.neoStorr.impl.testData.Person;
@@ -28,7 +28,7 @@ import uk.ac.standrews.cs.neoStorr.interfaces.IBucket;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TransactionsTest extends CommonTest {
 
@@ -74,7 +74,7 @@ public class TransactionsTest extends CommonTest {
     private List<Person> people = new ArrayList<>();
     private ITransaction transaction;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         super.setUp();
@@ -82,7 +82,7 @@ public class TransactionsTest extends CommonTest {
         bucket = repository.makeBucket(NEW_BUCKET_NAME, Person.class);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws RepositoryException {
 
         if (transaction != null && transaction.isActive()) transaction.rollback();
@@ -109,11 +109,13 @@ public class TransactionsTest extends CommonTest {
         assertThatPersistentRecordsContain("John", "Anna", "Rachel");
     }
 
-    @Test(expected = BucketException.class)
+    @Test
     public void createOutsideTransaction() throws BucketException {
 
         store.getTransactionManager().setAutoCommit(false);
-        makePersistentPerson();
+        assertThrows(BucketException.class, () -> {
+            makePersistentPerson();
+        });
     }
 
     @Test
@@ -140,7 +142,7 @@ public class TransactionsTest extends CommonTest {
         assertThatPersistentRecordsContain("John", "Anna", "Rachel");
     }
 
-    @Test(expected = BucketException.class)
+    @Test
     public void createWithRollback() throws Exception {
 
         store.getTransactionManager().setAutoCommit(false);
@@ -150,7 +152,9 @@ public class TransactionsTest extends CommonTest {
         transaction.rollback();
 
         bucket.invalidateCache();
-        bucket.getObjectById(people.get(0).getId());
+        assertThrows(BucketException.class, () -> {
+            bucket.getObjectById(people.get(0).getId());
+        });
     }
 
     @Test
@@ -177,13 +181,16 @@ public class TransactionsTest extends CommonTest {
         assertThatPersistentRecordsContain("Fred", "Jean", "Sian");
     }
 
-    @Test(expected = BucketException.class)
+    @Test
     public void updateOutsideTransaction() throws Exception {
 
         store.getTransactionManager().setAutoCommit(false);
-        makePersistentPerson();
 
-        updatePerson();
+        assertThrows(BucketException.class, () -> {
+            makePersistentPerson();
+            updatePerson();
+        });
+
     }
 
     @Test

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.parallel.enabled = false


### PR DESCRIPTION
## Warning
This pull-request is to replace PR #11 and will likely cause issues if it is merged without first rolling back #11 .

## Overview
Large patch, updates dependencies to include patches to String `measures` package (addresses a breaking bug if the Unicode replacement character was encountered). Also implements stricter typing to address compiler warnings and updates unit-tests to use JUnit5 and a Neo4J test harness. Updates Neo4J versions to 5+ to address character encoding issues.
 
Closes #7, closes #8,  closes #10, closes #12, closes #14, closes #15

## Changelist
**Additions:**
- Adds a basic README.

**Dependencies:**
- Updates [`common-pom`](https://github.com/stacs-srg/common-pom/) to [`4.1.0-SNAPSHOT`](https://github.com/stacs-srg/common-pom/pull/5) to take advantage of updated JDK and JUnit dependencies.
- Adds `JUnit5` dependency and migrates all tests to use this instead of discontinued JUnit4.
- Update the [`utilities`](https://github.com/stacs-srg/utilities/) dependency to [`1.1.0-SNAPSHOT`](https://github.com/stacs-srg/utilities/pull/13) to take advantages of latest patches to bugs in the `measures` package.
- Updated `neo4j` server dependency to `5.26.9` and `neo4J.driver` to Neo4j `5.26.3` (to bring in-line with the version used in the data-umea repo).
     - Fixes issues with character encoding (see [population linkage issue 20](https://github.com/stacs-srg/population-linkage/issues/20)).
- Adds Neo4J test harness to emulate the Neo4J instance for unit-tests.

**Repository:**
- Updates Maven target version to JDK 21.
- Re-enables unit-tests (as these can now run properly due to the presence of the test harness.

**Refactoring:**
- Renames "Class clazz" variables to c for clarity/conciseness .
- Fixes inaccurate exception messages in LXP.
- Removes unnecessary implementation of super-interface in NeoDbCypherBridge.

**Other:**
- Updated the default constructor for NeoDBBridge to use a host URL from a System property, 'NeoDBTestURL', if set. This facilitates unit-testing with JUnit harness.
- Disables tests running in parallel to prevent issues with test harnesses clashing with each-other.